### PR TITLE
Add links to Lirical & Exomiser into `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PhenopacketGenerator
-Generate a phenopacket for use with LIRICAL or Exomiser.
+Generate a phenopacket for use with [LIRICAL](https://github.com/TheJacksonLaboratory/LIRICAL) or [Exomiser](https://github.com/exomiser/Exomiser).
 
 
 ## Building PhenopacketGenerator


### PR DESCRIPTION
I think adding links to Lirical and Exomiser will make the README file clearer.